### PR TITLE
Fix stopExpireUser mail sending error

### DIFF
--- a/Library/Helper/Cron/StopExpireUser.php
+++ b/Library/Helper/Cron/StopExpireUser.php
@@ -29,7 +29,7 @@ class StopExpireUser implements ICron
     {
         $users = User::getUserArrayByExpire();
         $notificationMail = Option::get('mail_stop_expire_notification');
-        $mailContent = Option::get('custom_mail_stop_expire_content');
+        $mailContentTemplate = Option::get('custom_mail_stop_expire_content');
 
         if (!$notificationMail) {
             Option::set('mail_stop_expire_notification', 0); // 设置邮件提醒的系统参数
@@ -51,7 +51,7 @@ class StopExpireUser implements ICron
                     'transfer' => Utils::flowAutoShow($user->transfer),
                     'expireTime' => date('Y-m-d H:i:s', $user->expireTime)
                 ];
-                $mailContent = Utils::placeholderReplace($mailContent, $params);
+                $mailContent = Utils::placeholderReplace($mailContentTemplate, $params);
                 $mailContent .= "<p style=\"padding: 1.5em 1em 0; color: #999; font-size: 12px;\">—— 本邮件由 ". SITE_NAME ." (<a href=\"".BASE_URL."\">".BASE_URL."</a>) 账户管控系统发送</p>";
                 $mail->content = $mailContent;
                 $mailer->send($mail);


### PR DESCRIPTION
fix stopExpireUser  mail content error.

修复发送给停止过期用户的邮件内容错误,原来是把mailContent的邮件占位符替换后,再将mailContent传过去替换,导致第一次替换后再也没有了占位符
